### PR TITLE
Upcoming Puppet 3.7 / PE 3.4 x64 compatibility changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2014-08-12 - Release 1.1.0
+
+* Use Puppet::Util::Windows::ADSI for wmi connections with Puppet::Util::ADSI as a fallback for Puppet 3.7/PE 3.4 compatibility
+
 # 2014-07-19 - Release 1.0.0
 
 * Initial Commit

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ptierno-windowspagefile",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "ptierno",
   "summary": "Puppet type and provider to manage windows page files",
   "license": "Apache 2.0",


### PR DESCRIPTION
As part of making Puppet compatible with Windows x64 / Ruby 2, we have had to make a number of changes to our included gems, and have removed `sys-admin`, `windows-pr`, `win32-api` and `windows-api`.  Other gems have been upgraded to versions that require FFI and are compatible with x64.  We have made some other minor reorganizations to the classes in our Windows namespace.

We don't have builds released yet, but keep an eye on https://groups.google.com/forum/#!forum/puppet-announce

I have identified a small issue with the code in this module that will require some updating to ensure it maintains compatibility with both existing Puppet releases and the upcoming releases.  I'm getting in touch with you now, so that you're not caught off guard, and so that your module is ready to go by the time 3.7 ships.

Issue:
- Uses class `Puppet::Util::ADSI`, which is now at `Puppet::Util::Windows::ADSI`.  I would suggest that you store the class locally in a variable, with a graceful fallback type solution like:

``` ruby
ADSI = Puppet::Util::Windows::ADSI || Puppet::Util::ADSI
```

We will be making an announcement to the puppet-dev list shortly mentioning some of these upcoming changes.
https://groups.google.com/forum/#!forum/puppet-dev

Let me know if you have any questions.

Thanks!
