### PR TITLE
Fix issue with munge

### DIFF
--- a/lib/puppet/type/pagefile.rb
+++ b/lib/puppet/type/pagefile.rb
@@ -11,7 +11,7 @@ Puppet::Type.newtype(:pagefile) do
     end
 
     munge do |value|
-      if Facter['operatingsystemrelease'] =~ /2012/
+      if Facter.value(:operatingsystemrelease) =~ /2012/
         value.downcase
       else
         value.capitalize


### PR DESCRIPTION
Fixes issue #3

The commit e9b4208 introduced an issue where the
pagefile name was not munging correctly. This was due
to not retrieving the Facter value for operatingsystemrelease
properly.